### PR TITLE
Mount SSH key for database downloads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ Tellus API and import  module.
     http://127.0.0.1:8000/status/data
 
 ### Importeer de meest recente database van acceptatie:
+Als je SSH sleutel bekend is bij Datapunt kun je de acceptatie database
+downloaden naar een lokaal draaiende versie van het Tellus project (in
+het voorbeeld moet je `username` vervangen door jouw username bij Datapunt).
 
-    docker-compose exec database update-db.sh tellus
+    docker-compose exec database update-db.sh tellus <username>
 
 ### Tellus import
 #### Location of the datafiles

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_DB: tellus
       POSTGRES_USER: tellus
       POSTGRES_PASSWORD: insecure
+    volumes:
+      - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
 
   web:
     build: ./web


### PR DESCRIPTION
kleine README fix + ssh sleutel mounten in docker-compose.yml