### PR TITLE
Upgraded to Django 2.1.14

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -12,7 +12,7 @@ datapunt-authorization-levels==0.1.3
 dateutils==0.6.6
 debtcollector==1.20.0
 defusedxml==0.5.0
-Django==2.1.10
+Django==2.1.14
 django-braces==1.13.0
 django-extensions==2.1.2
 django-filter==2.0.0


### PR DESCRIPTION
Updating to latest version of Django (see https://docs.djangoproject.com/en/2.2/releases/2.1.14/). Specifically 2.1.11 is important given its security updates (https://docs.djangoproject.com/en/2.2/releases/2.1.11/).