### PR TITLE
Upgraded to Django 3.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,8 +3,7 @@
 
 # base
 #
-# https://github.com/chibisov/drf-extensions/issues/294 prevents upgrade to >= 3.1
-Django<3.1
+Django
 psycopg2-binary
 sentry-sdk
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ django-extensions==3.1.1
     # via -r requirements.in
 django-filter==2.4.0
     # via -r requirements.in
-django==3.0.13
+django==3.1.7
     # via
     #   -r requirements.in
     #   datapunt-authorization-django

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -72,7 +72,7 @@ django-extensions==3.1.1
     # via -r ./requirements.txt
 django-filter==2.4.0
     # via -r ./requirements.txt
-django==3.0.13
+django==3.1.7
     # via
     #   -r ./requirements.txt
     #   datapunt-authorization-django


### PR DESCRIPTION
drf-extensions finally released a new version, adding support for
Django 3.1: https://github.com/chibisov/drf-extensions/releases/tag/0.7.0